### PR TITLE
Add random_int with polyfill suggestions as default random generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Static function class to generate a correct url for the QR code, so you can easy
 
 There are also older open source versions of the Google Authenticator app for both [iPhone](https://github.com/google/google-authenticator) and [Android](https://github.com/google/google-authenticator-android)
 
+This helper class uses the random_int function from PHP7, or the polyfill method from [paragonie/random_compat](https://packagist.org/packages/paragonie/random_compat) if present and falls back on other (less "secure") random generators.
+
 About
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["otp","hotp","totp","googleauthenticator","rfc4226","rfc6238"],
     "homepage": "https://github.com/ChristianRiesen/otp",
     "license": "MIT",
-	"authors": [
+    "authors": [
         {
             "name": "Christian Riesen",
             "email": "chris.riesen@gmail.com",
@@ -15,12 +15,14 @@
     ],
     "require": {
         "php": ">=5.3.0",
-		"christian-riesen/base32": ">=1.0"
+        "christian-riesen/base32": ">=1.0"
     },
-	"autoload": {
+    "suggest": {
+        "paragonie/random_compat": "Optional polyfill for a more secure random generator for pre PHP7 versions"
+    },
+    "autoload": {
         "psr-0": {
             "Otp": "src"
         }
     }
 }
-

--- a/src/Otp/GoogleAuthenticator.php
+++ b/src/Otp/GoogleAuthenticator.php
@@ -163,9 +163,17 @@ class GoogleAuthenticator
         return $string;
     }
 
+    /**
+     * Get random number
+     *
+     * @return int Random number between 0 and 31 (including)
+     */
     private static function getRand()
     {
-        if (function_exists('openssl_random_pseudo_bytes')) {
+        if (function_exists('random_int')) {
+            // Uses either the PHP7 internal function or the polyfill if present
+            return random_int(0, 31);
+        } elseif (function_exists('openssl_random_pseudo_bytes')) {
             $bytes = openssl_random_pseudo_bytes(2);
             $number = hexdec(bin2hex($bytes));
 


### PR DESCRIPTION
Not a BC. Just will use that first, if present. In PHP7 it's already part of the core, and the polyfill can be installed to take care of the rest. Always will fall back to the current methods. Fixes #8.

Thanks to @inanimatt for the suggestion.
